### PR TITLE
CTA component (both primary and secondary variants) WIP

### DIFF
--- a/addon/components/cta.js
+++ b/addon/components/cta.js
@@ -1,0 +1,7 @@
+import Component from '@ember/component';
+import layout from '../templates/components/cta';
+
+export default Component.extend({
+  layout,
+  type: 'primary'
+});

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -1,2 +1,3 @@
 @import 'variables';
 @import 'main';
+@import 'components/cta';

--- a/addon/styles/components/cta.scss
+++ b/addon/styles/components/cta.scss
@@ -1,0 +1,27 @@
+$btn-primary: #1a1a1a;
+$btn-primary--hover: #5d5d5d;
+$btn-secondary: #a3a3a3;
+
+.cta-button {
+  padding: 8px 20px;
+  transition: .5s;
+  cursor: pointer;
+
+  &, &--primary {
+    background-color: $btn-primary;
+    color: white;
+
+    &:hover {
+      background-color: $btn-primary--hover;
+    }
+  }
+
+  &--secondary {
+    background-color: white;
+    color: $btn-secondary;
+
+    &:hover {
+      background-color: $btn-primary;
+    }
+  }
+}

--- a/addon/styles/components/cta.scss
+++ b/addon/styles/components/cta.scss
@@ -1,6 +1,9 @@
-$btn-primary: #1a1a1a;
-$btn-primary--hover: #5d5d5d;
-$btn-secondary: #a3a3a3;
+$gray: #5d5d5d;
+$light-gray: #a3a3a3;
+$dark-gray: #1a1a1a;
+$btn-primary: $dark-gray;
+$btn-primary-hover: $gray;
+$btn-secondary: $light-gray;
 
 .cta-button {
   padding: 8px 20px;
@@ -12,7 +15,7 @@ $btn-secondary: #a3a3a3;
     color: white;
 
     &:hover {
-      background-color: $btn-primary--hover;
+      background-color: $btn-primary-hover;
     }
   }
 

--- a/addon/styles/components/cta.scss
+++ b/addon/styles/components/cta.scss
@@ -19,6 +19,7 @@ $btn-secondary: #a3a3a3;
   &--secondary {
     background-color: white;
     color: $btn-secondary;
+    border-color: $btn-secondary;
 
     &:hover {
       background-color: $btn-primary;

--- a/addon/templates/components/cta.hbs
+++ b/addon/templates/components/cta.hbs
@@ -1,0 +1,6 @@
+<button
+  class="cta-button cta-button--{{@type}}"
+  data-cta-button
+>
+  {{yield}}
+</button>

--- a/app/components/cta.js
+++ b/app/components/cta.js
@@ -1,0 +1,1 @@
+export { default } from '@cardstack/ui-components/components/cta';

--- a/tests/dummy/app/templates/freestyle.hbs
+++ b/tests/dummy/app/templates/freestyle.hbs
@@ -31,4 +31,21 @@
 
   {{/freestyle-section}}
 
+  {{#freestyle-section name="CTA"}}
+    {{#freestyle-usage "primary-cta" title="Primary CTA"}}
+      <Cta @type="primary">Primary Call to Action</Cta>
+    {{/freestyle-usage}}
+
+    {{#freestyle-usage "secondary-cta" title="Secondary CTA"}}
+      <Cta @type="secondary">Secondary Call to Action</Cta>
+    {{/freestyle-usage}}
+
+    {{#freestyle-usage "default-cta" title="Default CTA"}}
+      <Cta>Call to Action</Cta>
+    {{/freestyle-usage}}
+    {{#freestyle-note "default-cta--notes"}}
+      <p>By default, <code>Cta</code> will render a primary type</p>
+    {{/freestyle-note}}
+  {{/freestyle-section}}
+
 {{/freestyle-guide}}

--- a/tests/dummy/app/templates/freestyle.hbs
+++ b/tests/dummy/app/templates/freestyle.hbs
@@ -32,20 +32,25 @@
   {{/freestyle-section}}
 
   {{#freestyle-section name="CTA"}}
-    {{#freestyle-usage "primary-cta" title="Primary CTA"}}
-      <Cta @type="primary">Primary Call to Action</Cta>
-    {{/freestyle-usage}}
 
-    {{#freestyle-usage "secondary-cta" title="Secondary CTA"}}
-      <Cta @type="secondary">Secondary Call to Action</Cta>
-    {{/freestyle-usage}}
+    {{#freestyle-collection title="CTA" defaultKey="primary" inline=true as |collection|}}
+      {{#collection.variant key="primary"}}
+        {{#freestyle-usage "primary-cta" title="Primary CTA"}}
+          <Cta @type="primary">Primary Call to Action</Cta>
+        {{/freestyle-usage}}
 
-    {{#freestyle-usage "default-cta" title="Default CTA"}}
-      <Cta>Call to Action</Cta>
-    {{/freestyle-usage}}
-    {{#freestyle-note "default-cta--notes"}}
-      <p>By default, <code>Cta</code> will render a primary type</p>
-    {{/freestyle-note}}
+      {{/collection.variant}}
+      {{#freestyle-note "primary-cta--notes"}}
+        By default, `Cta` will render a primary type
+      {{/freestyle-note}}
+
+      {{#collection.variant key="secondary"}}
+        {{#freestyle-usage "secondary-cta" title="Secondary CTA"}}
+          <Cta @type="secondary">Secondary Call to Action</Cta>
+        {{/freestyle-usage}}
+      {{/collection.variant}}
+    {{/freestyle-collection}}
+
   {{/freestyle-section}}
 
 {{/freestyle-guide}}


### PR DESCRIPTION
Closes #6 

This PR includes:

- The primary and secondary CTA button. This is only the button and styles, and does not include anything that handles clicks.
- Section in ember-freestyle for the CTA component

<img width="939" alt="Screen Shot 2019-04-24 at 8 09 37 AM" src="https://user-images.githubusercontent.com/118005/56670816-57f7cb80-6668-11e9-9e89-970b8667fd6c.png">
