### PR TITLE
Add Percy and A11y tests to freestyle page

### DIFF
--- a/tests/acceptance/components-test.js
+++ b/tests/acceptance/components-test.js
@@ -2,14 +2,18 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { percySnapshot } from 'ember-percy';
+import a11yAudit from 'ember-a11y-testing/test-support/audit';
 
 module('Acceptance | components', function(hooks) {
   setupApplicationTest(hooks);
 
   test('components visual check', async function(assert) {
-    await visit('/');
-    assert.equal(currentURL(), '/');
+    await visit('/freestyle');
+    assert.equal(currentURL(), '/freestyle');
 
     percySnapshot('UI Components');
+
+    await a11yAudit();
+    assert.ok(true, 'no a11y errors found!');
   });
 });

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -1,0 +1,13 @@
+.FreestyleGuide {
+  .hljs-deletion, .hljs-string, .hljs-built_in, .hljs-builtin-name {
+    color: white;
+  }
+
+  .hljs-comment {
+    color: #bcf2bc;
+  }
+
+  .FreestyleMenu-itemLink.active {
+    color: #005a66;
+  }
+}

--- a/tests/dummy/app/templates/freestyle.hbs
+++ b/tests/dummy/app/templates/freestyle.hbs
@@ -3,34 +3,6 @@
   subtitle="Living Style Guide"
   }}
 
-  {{#freestyle-section name="Visual Style" as |section|}}
-
-    {{#section.subsection name="Typography"}}
-
-      {{#freestyle-usage "typography-times" title="Times New Roman"}}
-        {{freestyle-typeface fontFamily="Times New Roman"}}
-      {{/freestyle-usage}}
-
-      {{#freestyle-usage "typography-helvetica" title="Helvetica"}}
-        {{freestyle-typeface fontFamily="Helvetica"}}
-      {{/freestyle-usage}}
-
-    {{/section.subsection}}
-
-    {{#section.subsection name="Color"}}
-
-      {{#freestyle-usage "fp" title="Freestyle Palette" usageTitle="Usage"}}
-        {{freestyle-palette
-        colorPalette=colorPalette
-        title="Dummy App Color Palette"
-        description="This component displays the color palette specified in freestyle/palette.json"
-        }}
-      {{/freestyle-usage}}
-
-    {{/section.subsection}}
-
-  {{/freestyle-section}}
-
   {{#freestyle-section name="CTA"}}
 
     {{#freestyle-collection title="CTA" defaultKey="primary" inline=true as |collection|}}


### PR DESCRIPTION
I removed some of the boilerplate Freestyle stuff (typography, palette) to get a11y tests passing. Presumably those will be important later, but for now we can punt 🏈 ¯\_(ツ)_/¯