### PR TITLE
Don’t namespace public assets folder during build

### DIFF
--- a/addon/styles/components/choose-many.scss
+++ b/addon/styles/components/choose-many.scss
@@ -55,7 +55,7 @@
     width: 12px;
     height: 12px;
     margin-left: 5px;
-    background-image: url("/@cardstack/ui-components/images/icon-checked.svg");
+    background-image: url("/images/icon-checked.svg");
     background-size: 12px 12px;
     background-repeat: no-repeat;
   }

--- a/addon/styles/components/choose-one.scss
+++ b/addon/styles/components/choose-one.scss
@@ -59,7 +59,7 @@
     width: 12px;
     height: 12px;
     margin-left: 5px;
-    background-image: url("/@cardstack/ui-components/images/icon-checked.svg");
+    background-image: url("/images/icon-checked.svg");
     background-size: 12px 12px;
     background-repeat: no-repeat;
   }

--- a/addon/styles/components/text-field.scss
+++ b/addon/styles/components/text-field.scss
@@ -3,7 +3,7 @@
   --cs-component-text-field-border-radius: var(--cs-input-border-radius);
   --cs-component-text-field-label: var(--cs-input-label);
   --cs-component-text-field-validation: var(--cs-input-valid);
-  --cs-component-text-field-validation-icon: url('/@cardstack/ui-components/images/check-icon.svg');
+  --cs-component-text-field-validation-icon: url('/images/check-icon.svg');
   --cs-component-text-field-validation-icon-size: 1em;
 
   position: relative;
@@ -110,7 +110,7 @@
 
   &.invalid {
     --cs-component-text-field-validation: var(--cs-input-invalid);
-    --cs-component-text-field-validation-icon: url('/@cardstack/ui-components/images/x-icon.svg');
+    --cs-component-text-field-validation-icon: url('/images/x-icon.svg');
 
     visibility: visible;
   }

--- a/addon/styles/main.scss
+++ b/addon/styles/main.scss
@@ -2,64 +2,64 @@
 
 @font-face {
   font-family: 'Open Sans';
-  src: url('/@cardstack/ui-components/fonts/OpenSans-Light.ttf');
+  src: url('/fonts/OpenSans-Light.ttf');
   font-weight: 300;
 }
 
 @font-face {
   font-family: 'Open Sans';
-  src: url('/@cardstack/ui-components/fonts/OpenSans-LightItalic.ttf');
+  src: url('/fonts/OpenSans-LightItalic.ttf');
   font-weight: 300;
   font-style: italic;
 }
 
 @font-face {
   font-family: 'Open Sans';
-  src: url('/@cardstack/ui-components/fonts/OpenSans-Regular.ttf');
+  src: url('/fonts/OpenSans-Regular.ttf');
   font-weight: 400;
 }
 
 @font-face {
   font-family: 'Open Sans';
-  src: url('/@cardstack/ui-components/fonts/OpenSans-Italic.ttf');
+  src: url('/fonts/OpenSans-Italic.ttf');
   font-style: italic;
 }
 
 @font-face {
   font-family: 'Open Sans';
-  src: url('/@cardstack/ui-components/fonts/OpenSans-SemiBold.ttf');
+  src: url('/fonts/OpenSans-SemiBold.ttf');
   font-weight: 600;
 }
 
 @font-face {
   font-family: 'Open Sans';
-  src: url('/@cardstack/ui-components/fonts/OpenSans-SemiBoldItalic.ttf');
+  src: url('/fonts/OpenSans-SemiBoldItalic.ttf');
   font-weight: 600;
   font-style: italic;
 }
 
 @font-face {
   font-family: 'Open Sans';
-  src: url('/@cardstack/ui-components/fonts/OpenSans-Bold.ttf');
+  src: url('/fonts/OpenSans-Bold.ttf');
   font-weight: 700;
 }
 
 @font-face {
   font-family: 'Open Sans';
-  src: url('/@cardstack/ui-components/fonts/OpenSans-BoldItalic.ttf');
+  src: url('/fonts/OpenSans-BoldItalic.ttf');
   font-weight: 700;
   font-style: italic;
 }
 
 @font-face {
   font-family: 'Open Sans';
-  src: url('/@cardstack/ui-components/fonts/OpenSans-ExtraBold.ttf');
+  src: url('/fonts/OpenSans-ExtraBold.ttf');
   font-weight: 800;
 }
 
 @font-face {
   font-family: 'Open Sans';
-  src: url('/@cardstack/ui-components/fonts/OpenSans-ExtraBoldItalic.ttf');
+  src: url('/fonts/OpenSans-ExtraBoldItalic.ttf');
   font-weight: 800;
   font-style: italic;
 }

--- a/index.js
+++ b/index.js
@@ -1,4 +1,6 @@
 'use strict';
+const Funnel = require('broccoli-funnel');
+const mergeTrees = require('broccoli-merge-trees');
 
 module.exports = {
   name: require('./package').name,
@@ -7,5 +9,11 @@ module.exports = {
   },
   included: function(/* app */) {
     this._super.included.apply(this, arguments);
+  },
+  treeForPublic: function(tree) {
+    const assetsTree = new Funnel('public');
+    return mergeTrees([tree, assetsTree], {
+      overwrite: true,
+    });
   }
 };

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "test:all": "ember try:each"
   },
   "dependencies": {
+    "broccoli-funnel": "^2.0.2",
+    "broccoli-merge-trees": "^3.0.2",
     "ember-cli-babel": "^7.1.2",
     "ember-cli-htmlbars": "^3.0.0",
     "ember-cli-sass": "^10.0.0",


### PR DESCRIPTION
This fixes the font and image paths in our "production" site on [GH pages](https://cardstack.github.io/ui-components/)