### PR TITLE
Drop invalid unused files

### DIFF
--- a/app/components/phone-number-field/input.js
+++ b/app/components/phone-number-field/input.js
@@ -1,1 +1,0 @@
-export { default } from '@cardstack/ui-components/components/phone-number-field/input';

--- a/app/components/text-field/input.js
+++ b/app/components/text-field/input.js
@@ -1,1 +1,0 @@
-export { default } from '@cardstack/ui-components/components/text-field/input';


### PR DESCRIPTION
These both refer to components that don't exist.

This can break under embroider when using `staticAddonTrees: false`. It doesn't happen to break in cardhost at the moment because we have `staticAddonTrees: true`, so these spurious files get ignored there.