### PR TITLE
use one way binding for checkbox

### DIFF
--- a/addon/components/checkbox.js
+++ b/addon/components/checkbox.js
@@ -20,7 +20,7 @@ export default class Checkbox extends BaseComponent {
     let checked = ev.target.checked;
 
     this.value = value;
-    this.checked = checked;
+    this.args.setChecked(checked)
 
     if (checked && !this.required) {
       this.invalid = false;

--- a/app/templates/components/checkbox.hbs
+++ b/app/templates/components/checkbox.hbs
@@ -6,7 +6,7 @@
     class="cs-component-checkbox--input {{if @required "required"}}"
     id={{concat "checkbox-input-" this.elementId}}
     required={{@required}}
-    onchange={{action this.handleInput}}
+    {{on "change" this.handleInput}}
     disabled={{@disabled}}
   >
 

--- a/testem.js
+++ b/testem.js
@@ -13,7 +13,6 @@ module.exports = {
         // --no-sandbox is needed when running Chrome inside a container
         process.env.CI ? '--no-sandbox' : null,
         '--headless',
-        '--disable-gpu',
         '--disable-dev-shm-usage',
         '--disable-software-rasterizer',
         '--mute-audio',

--- a/tests/dummy/app/controllers/examples/registration.js
+++ b/tests/dummy/app/controllers/examples/registration.js
@@ -6,5 +6,10 @@ export default Controller.extend({
   sourceOptions: A([ 'Magazine', 'Radio', 'EmberConf', 'Other']),
   isSubmitDisabled: computed('emailValue', 'isEmailValid', 'passwordValue', 'isPasswordValid', 'isCheckboxChecked', function() {
     return !(!!this.emailValue && !this.isEmailInvalid && !!this.passwordValue && !this.isPasswordInvalid && this.isCheckboxChecked);
-  })
+  }),
+  actions: {
+    setChecked(val) {
+      this.set('isCheckboxChecked', val);
+    }
+  }
 });

--- a/tests/dummy/app/controllers/examples/registration.js
+++ b/tests/dummy/app/controllers/examples/registration.js
@@ -1,15 +1,14 @@
 import Controller from '@ember/controller';
 import { A } from '@ember/array';
-import { computed } from '@ember/object';
+import { computed, action } from '@ember/object';
 
 export default Controller.extend({
   sourceOptions: A([ 'Magazine', 'Radio', 'EmberConf', 'Other']),
   isSubmitDisabled: computed('emailValue', 'isEmailValid', 'passwordValue', 'isPasswordValid', 'isCheckboxChecked', function() {
     return !(!!this.emailValue && !this.isEmailInvalid && !!this.passwordValue && !this.isPasswordInvalid && this.isCheckboxChecked);
   }),
-  actions: {
-    setChecked(val) {
-      this.set('isCheckboxChecked', val);
-    }
-  }
+  
+  setChecked: action(function(propertyToSet, val) {
+    this.set(propertyToSet, val);
+  })
 });

--- a/tests/dummy/app/controllers/freestyle.js
+++ b/tests/dummy/app/controllers/freestyle.js
@@ -129,10 +129,16 @@ export default Ember.Component.extend({
   // val comes from the arg you pass in when calling the action
 
   // BEGIN-FREESTYLE-USAGE checkbox-action
+  // Classic Ember:
   setChecked: action(function(propertyToSet, val) {
     this.set(propertyToSet, val)
   })
 
+  // Octane:
+  // @action
+  // setChecked(propertyToSet, val) {
+  //  this[propertyToSet] = val;
+  // }
 
   // END-FREESTYLE-USAGE
 });

--- a/tests/dummy/app/controllers/freestyle.js
+++ b/tests/dummy/app/controllers/freestyle.js
@@ -2,6 +2,7 @@ import { inject as service } from '@ember/service';
 import { A } from '@ember/array';
 import { computed } from '@ember/object';
 import FreestyleController from 'ember-freestyle/controllers/freestyle';
+import { action } from '@ember/object';
 
 const countries = [
   { name: 'United States', formalName: 'United States of America' },
@@ -120,5 +121,18 @@ export default Ember.Component.extend({
       valid: value === 'cardstack',
       message: 'Password must be "cardstack"'
     };
-  }
+  },
+
+  isChecked: false,
+  // We use `action()` here so that we can use the `this` context.
+  // propertyToSet comes from the arg bound by `{{fn}}` and
+  // val comes from the arg you pass in when calling the action
+
+  // BEGIN-FREESTYLE-USAGE checkbox-action
+  setChecked: action(function(propertyToSet, val) {
+    this.set(propertyToSet, val)
+  })
+
+
+  // END-FREESTYLE-USAGE
 });

--- a/tests/dummy/app/templates/examples/registration.hbs
+++ b/tests/dummy/app/templates/examples/registration.hbs
@@ -12,7 +12,7 @@
       @label="I accept the Cardstack Terms &amp; Conditions"
       @required={{true}}
       @checked={{this.isCheckboxChecked}}
-      @setChecked={{action "setChecked"}} />
+      @setChecked={{fn this.setChecked "isCheckboxChecked"}} />
     <Cta @disabled={{this.isSubmitDisabled}}>Submit</Cta>
   </div>
 </section>

--- a/tests/dummy/app/templates/examples/registration.hbs
+++ b/tests/dummy/app/templates/examples/registration.hbs
@@ -16,5 +16,3 @@
     <Cta @disabled={{this.isSubmitDisabled}}>Submit</Cta>
   </div>
 </section>
-
-Checked: {{this.isCheckboxChecked}}

--- a/tests/dummy/app/templates/examples/registration.hbs
+++ b/tests/dummy/app/templates/examples/registration.hbs
@@ -8,7 +8,13 @@
   <div class="example-form">
     <Email @label="Email" @required={{true}} @value={{this.emailValue}} @invalid={{this.isEmailInvalid}}/>
     <PasswordField @required={{true}} @value={{this.passwordValue}} @invalid={{this.isPasswordInvalid}} />
-    <Checkbox @label="I accept the Cardstack Terms &amp; Conditions" @required={{true}} @checked={{this.isCheckboxChecked}} />
+    <Checkbox
+      @label="I accept the Cardstack Terms &amp; Conditions"
+      @required={{true}}
+      @checked={{this.isCheckboxChecked}}
+      @setChecked={{action "setChecked"}} />
     <Cta @disabled={{this.isSubmitDisabled}}>Submit</Cta>
   </div>
 </section>
+
+Checked: {{this.isCheckboxChecked}}

--- a/tests/dummy/app/templates/freestyle.hbs
+++ b/tests/dummy/app/templates/freestyle.hbs
@@ -616,17 +616,21 @@
 
   {{!-- CHECKBOX --}}
   {{#freestyle-section name="Checkbox (boolean)"}}
+    {{#freestyle-annotation}}
+      <p>All Checkboxes require passing in a <code>setChecked</code> function that fires when the checkbox is clicked. The function receives two params, the name of the property to set, and the value (true or false).</p>
+    {{/freestyle-annotation}}
+    {{freestyle-usage "checkbox-action" title="Example Action"}}
     {{#freestyle-usage "checkbox-default" title="Default (Optional)"}}
-      <Checkbox @label="Include a free gift in my order" />
+      <Checkbox @label="Include a free gift in my order" @setChecked={{fn this.setChecked "checkedOne"}} @checked={{false}} />
     {{/freestyle-usage}}
     {{#freestyle-usage "checkbox-required" title="Required"}}
-      <Checkbox @label="I accept the Cardstack Terms of Service" @required={{true}} />
+      <Checkbox @label="I accept the Cardstack Terms of Service" @required={{true}} @setChecked={{fn this.setChecked "checkedTwo"}} @checked={{false}} />
     {{/freestyle-usage}}
     {{#freestyle-usage "checkbox-disabled" title="Disabled"}}
-      <Checkbox @label="Enable Dark Mode" @disabled={{true}} />
+      <Checkbox @label="Enable Dark Mode" @disabled={{true}} @setChecked={{fn this.setChecked "checkedThree"}} @checked={{this.isChecked}} />
     {{/freestyle-usage}}
     {{#freestyle-usage "checkbox-default-checked" title="Default Checked"}}
-      <Checkbox @label="I would like to subscribe to your newsletter" @checked={{true}} />
+      <Checkbox @label="I would like to subscribe to your newsletter" @checked={{true}} @setChecked={{fn this.setChecked "checkedFour"}} />
     {{/freestyle-usage}}
     {{!-- TODO: Themed version --}}
   {{/freestyle-section}}

--- a/tests/integration/checkbox-test.js
+++ b/tests/integration/checkbox-test.js
@@ -3,11 +3,18 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
+
 module('Integration | Component | checkbox', function(hooks) {
   setupRenderingTest(hooks);
-
+  
+  
   test('component can be checked', async function(assert) {
-    await render(hbs`<Checkbox @label="By clicking Submit you agree to the Cardstack Terms and Conditions™" />`);
+    assert.expect(3)
+    this.set('setChecked', function(val) {
+      assert.equal(val, true)
+    });
+    
+    await render(hbs`<Checkbox @label="By clicking Submit you agree to the Cardstack Terms and Conditions™" @setChecked={{fn this.setChecked}} />`);
 
     assert.dom('.cs-component-checkbox input[type="checkbox"]').isNotChecked();
 
@@ -17,7 +24,14 @@ module('Integration | Component | checkbox', function(hooks) {
   });
 
   test('component can be disabled', async function(assert) {
-    await render(hbs`<Checkbox @label="You cannot click me" @disabled={{true}} />`);
+    assert.expect(2)
+
+    this.set('setChecked', function(val) {
+      // this should not run, which is why we expect(2)
+      assert.equal(val, undefined)
+    });
+
+    await render(hbs`<Checkbox @label="You cannot click me" @disabled={{true}} @setChecked={{fn this.setChecked "checked"}} />`);
 
     assert.dom('.cs-component-checkbox input[type="checkbox"]').isNotChecked();
 
@@ -27,7 +41,13 @@ module('Integration | Component | checkbox', function(hooks) {
   });
 
   test('component can default to checked', async function(assert) {
-    await render(hbs`<Checkbox @label="Yes I would like to receive your newsletter" @checked={{true}} />`);
+    assert.expect(3)
+
+    this.set('setChecked', function(val) {
+      assert.equal(val, false)
+    });
+
+    await render(hbs`<Checkbox @label="Yes I would like to receive your newsletter" @checked={{true}} @setChecked={{fn this.setChecked}} />`);
 
     assert.dom('.cs-component-checkbox input[type="checkbox"]').isChecked();
 
@@ -37,15 +57,19 @@ module('Integration | Component | checkbox', function(hooks) {
   });
 
   test('component can set value', async function(assert) {
+    this.set('setChecked', function() {});
+
     this.value = 'foo';
-    await render(hbs`<Checkbox @label="Click here" @value={{value}} />`);
+    await render(hbs`<Checkbox @label="Click here" @value={{value}} @setChecked={{fn this.setChecked}} />`);
 
     assert.dom('.cs-component-checkbox input[type="checkbox"]').isNotChecked();
     assert.dom('.cs-component-checkbox input[type="checkbox"]').hasValue('foo');
   });
 
   test('component can be required', async function(assert) {
-    await render(hbs`<Checkbox @label="By clicking Submit you agree to the Cardstack Terms and Conditions™" @required={{true}} />`);
+    this.set('setChecked', function() {});
+
+    await render(hbs`<Checkbox @label="By clicking Submit you agree to the Cardstack Terms and Conditions™" @required={{true}} @setChecked={{fn this.setChecked}} />`);
 
     assert.dom('.cs-component-checkbox input[type="checkbox"]').isNotChecked();
     assert.dom('.cs-component-checkbox input[type="checkbox"]').hasClass('required');
@@ -62,7 +86,9 @@ module('Integration | Component | checkbox', function(hooks) {
   });
 
   test('component can be disabled', async function(assert) {
-    await render(hbs`<Checkbox @label="I would like to sign up for your newsletter" @checked={{true}} @disabled={{true}} />`);
+    this.set('setChecked', function() {});
+
+    await render(hbs`<Checkbox @label="I would like to sign up for your newsletter" @checked={{true}} @disabled={{true}} @setChecked={{fn this.setChecked}} />`);
 
     assert.dom('.cs-component-checkbox input[type="checkbox"]').isChecked();
     assert.dom('.cs-component-checkbox input[type="checkbox"]').hasAttribute('disabled');


### PR DESCRIPTION
Changed:
- Checkbox is one-way bound, and requires passing in an action to use it
- Modified the tests to assert that the action is called
- updated all uses of checkbox

Added:
- An example of the action to the freestyle docs

What I didn't change was converting the Freestyle controller to native classes. It breaks the controls for the routes, meaning that you can't click on sidebar items and see just those docs. We'll probably have to make a change to freestyle if we want to update the controller.

The deprecations in freestyle are really noisy too, and we should probably try to fix that.

Closes #125 