### PR TITLE
turn off percy snapshots for non-PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,6 +77,7 @@ jobs:
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash
   - export PATH=$HOME/.yarn/bin:$PATH
+  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then PERCY_TOKEN="skip percy"; fi'
 
 install:
   - yarn install --no-lockfile --non-interactive


### PR DESCRIPTION
This PR turns off Percy snapshots for everything but Pull Requests.

We were triggering unnecessary snapshots because we run CI on all branches, not just PRs.

Note that a long-standing WIP pr with many pushes should be closed instead until it is ready, to avoid unnecessary charges.

Sister PR https://github.com/cardstack/cardstack/pull/1177