### PR TITLE
Skip percy tests for ember-try scenarios

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,9 @@ branches:
 jobs:
   fail_fast: true
   allow_failures:
-    - env: EMBER_TRY_SCENARIO=ember-lts-3.4
-    - env: EMBER_TRY_SCENARIO=ember-lts-3.8
-    - env: EMBER_TRY_SCENARIO=ember-canary
+    - env: EMBER_TRY_SCENARIO=ember-lts-3.4 PERCY_TOKEN="skip percy"
+    - env: EMBER_TRY_SCENARIO=ember-lts-3.8 PERCY_TOKEN="skip percy"
+    - env: EMBER_TRY_SCENARIO=ember-canary PERCY_TOKEN="skip percy"
 
   include:
     # runs linting and tests with current locked deps

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,11 +53,11 @@ jobs:
     # we recommend new addons test the current and previous LTS
     # as well as latest stable release (bonus points to beta/canary)
     - stage: "Additional Tests"
-      env: EMBER_TRY_SCENARIO=ember-lts-3.4
-    - env: EMBER_TRY_SCENARIO=ember-lts-3.8
-    - env: EMBER_TRY_SCENARIO=ember-release
-    - env: EMBER_TRY_SCENARIO=ember-beta
-    - env: EMBER_TRY_SCENARIO=ember-canary
+      env: EMBER_TRY_SCENARIO=ember-lts-3.4 PERCY_TOKEN="skip percy"
+    - env: EMBER_TRY_SCENARIO=ember-lts-3.8 PERCY_TOKEN="skip percy"
+    - env: EMBER_TRY_SCENARIO=ember-release PERCY_TOKEN="skip percy"
+    - env: EMBER_TRY_SCENARIO=ember-beta PERCY_TOKEN="skip percy"
+    - env: EMBER_TRY_SCENARIO=ember-canary PERCY_TOKEN="skip percy"
 
     - stage: deploy-gh-pages
       name: "Deploy to Github Pages"


### PR DESCRIPTION
We also need to skip percy snapshots for ember-try scenarios, or even for PRs we will get percy tests six times.